### PR TITLE
Add support for custom file copying via .workbloom config

### DIFF
--- a/.workbloom
+++ b/.workbloom
@@ -1,0 +1,18 @@
+# workbloom configuration file
+# Files and directories to copy to git worktrees
+
+# Rust development files
+Cargo.lock
+rust-toolchain.toml
+.cargo/config.toml
+
+# CI/CD configurations
+.github/workflows/
+
+# Development tools configuration
+.vscode/settings.json
+rustfmt.toml
+clippy.toml
+
+# Documentation
+docs/

--- a/.workbloom.example
+++ b/.workbloom.example
@@ -1,0 +1,30 @@
+# .workbloom - List of files and directories to copy to git worktrees
+# 
+# Format:
+# - One file or directory per line
+# - Lines starting with # are comments
+# - Empty lines are ignored
+# - Directories should end with /
+#
+# Example:
+
+# Environment and configuration files
+.envrc
+.env
+.env.local
+
+# Service account and credentials
+service-account.json
+.secret/credentials.json
+
+# Configuration files
+config/database.yml
+config/application.yml
+
+# Directories (end with /)
+certificates/
+.docker/config/
+
+# Claude AI settings (already copied by default, but can be specified here too)
+.claude/settings.json
+.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -92,11 +92,32 @@ workbloom cleanup --status
 
 ## Configuration
 
+### Default Files
+
 By default, Workbloom copies the following files to new worktrees:
 - `.envrc`
 - `.env`
 - `.claude/settings.json`
 - `.claude/settings.local.json`
+
+### Custom File Copying
+
+You can specify additional files and directories to copy by creating a `.workbloom` file in your repository root:
+
+```bash
+# .workbloom - List of files and directories to copy to git worktrees
+# One file or directory per line
+# Lines starting with # are comments
+# Directories should end with /
+
+# Example:
+service-account.json
+config/database.yml
+.secret/credentials.json
+certificates/
+```
+
+See `.workbloom.example` for a complete example.
 
 ## Port Allocation
 

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -9,7 +9,8 @@ use crate::{config::Config, file_ops, git::GitRepo, port};
 
 pub fn execute(branch_name: &str, start_shell: bool) -> Result<()> {
     let repo = GitRepo::new()?;
-    let config = Config::default();
+    let config = Config::load_from_file(&repo.root_dir)
+        .unwrap_or_else(|_| Config::default());
     
     let worktree_dir_name = format!("worktree-{}", branch_name.replace('/', "-"));
     let worktree_path = repo.root_dir.join(&worktree_dir_name);

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,7 @@
 use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::fs;
+use std::io::{self, BufRead, BufReader};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
@@ -20,5 +23,36 @@ impl Default for Config {
                 "settings.local.json".to_string(),
             ],
         }
+    }
+}
+
+impl Config {
+    pub fn load_from_file(repo_dir: &Path) -> io::Result<Self> {
+        let mut config = Self::default();
+        let workbloom_file = repo_dir.join(".workbloom");
+        
+        if workbloom_file.exists() {
+            let file = fs::File::open(&workbloom_file)?;
+            let reader = BufReader::new(file);
+            
+            for line in reader.lines() {
+                let line = line?;
+                let trimmed = line.trim();
+                
+                // Skip empty lines and comments
+                if trimmed.is_empty() || trimmed.starts_with('#') {
+                    continue;
+                }
+                
+                // Check if it's a directory (ends with /)
+                if trimmed.ends_with('/') {
+                    config.directories_to_copy.push(trimmed.trim_end_matches('/').to_string());
+                } else {
+                    config.files_to_copy.push(trimmed.to_string());
+                }
+            }
+        }
+        
+        Ok(config)
     }
 }


### PR DESCRIPTION
## Summary
- Add `.workbloom` file support to specify additional files/directories to copy to worktrees
- Maintain backward compatibility with default files
- Add example file and documentation

## Test plan
- [ ] Create a `.workbloom` file with some test files
- [ ] Run `workbloom setup feature/test-branch`
- [ ] Verify that both default files and custom files are copied
- [ ] Test with non-existent files (should show warning but continue)
- [ ] Test with directories

🤖 Generated with [Claude Code](https://claude.ai/code)