### PR TITLE
fix: Prevent automatic cleanup of newly created branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2025-07-05
+
+### Fixed
+- Prevent automatic cleanup of newly created branches during `workbloom setup`
+- Filter out branches with no unique commits from merge cleanup to avoid deleting fresh branches
+
+### Changed
+- Enhanced cleanup logic to distinguish between truly merged branches and newly created branches
+
 ## [0.1.2] - 2025-01-05
 
 ### Fixed
@@ -25,5 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial features
 
+[0.1.3]: https://github.com/chaspy/workbloom/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/chaspy/workbloom/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/chaspy/workbloom/releases/tag/v0.1.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workbloom"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["chaspy <chaspy+git@gmail.com>"]
 description = "A Git worktree management tool with automatic file copying and port allocation"

--- a/src/commands/cleanup.rs
+++ b/src/commands/cleanup.rs
@@ -52,6 +52,15 @@ fn get_filtered_merged_branches(repo: &GitRepo, exclude_branch: Option<&str>) ->
         merged_branches.retain(|branch| branch != exclude);
     }
     
+    // Filter out branches that have no unique commits (newly created branches)
+    // These appear as "merged" but are actually just new branches without any work
+    merged_branches.retain(|branch| {
+        match repo.has_unmerged_commits(branch) {
+            Ok(has_commits) => has_commits, // Keep only branches that have unique commits
+            Err(_) => true, // Keep branch if we can't determine (error case)
+        }
+    });
+    
     Ok(merged_branches)
 }
 


### PR DESCRIPTION
## Summary
- Fixes issue where `workbloom setup` automatically deletes previously created branches
- Enhances cleanup logic to distinguish between truly merged branches and newly created branches
- Filters out branches with no unique commits from merge cleanup

## Problem
When running `workbloom setup` multiple times with different branch names, the tool would automatically clean up previously created branches during the setup process. This happened because:

1. New branches created from main with no commits appear as "merged" to git
2. The cleanup logic treated these as legitimate merged branches to be removed
3. Users would lose their recently created worktrees unexpectedly

## Solution
Modified the `get_filtered_merged_branches()` function in `src/commands/cleanup.rs` to:
- Filter out branches that have no unique commits compared to main
- Only consider branches with actual work (commits) as candidates for cleanup
- Preserve newly created branches that haven't diverged from main yet

## Test plan
- [x] Create first test branch with `workbloom setup test-1`
- [x] Create second test branch with `workbloom setup test-2`
- [x] Verify that `test-1` worktree is not automatically deleted
- [x] Confirm cleanup logic still works for branches with actual commits
- [x] Version bump to 0.1.3

🤖 Generated with [Claude Code](https://claude.ai/code)