### PR TITLE
fix: Correctly identify and protect newly created branches from cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fix issue where newly created branches with no commits were incorrectly identified as merged branches and deleted
+- Implement proper detection of actually merged branches by checking merge commit parents
+
+### Added
+- New `was_branch_merged_to_main()` method that checks if a branch was actually merged via a merge commit
+- Additional 24-hour safety check for recently created worktrees
+
+### Changed
+- Improved branch cleanup logic to distinguish between truly merged branches and new branches that haven't diverged from main
+
 ## [0.1.3] - 2025-07-05
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Fixes issue where newly created branches were incorrectly deleted as "merged" branches
- Implements proper detection of actually merged branches by checking merge commit parents
- Adds additional safety checks to protect recently created worktrees

## Problem
When creating a new branch (like `message-crud2`), it was being incorrectly identified as a "merged" branch because it shares the same commit as main. This caused the cleanup process to delete active work branches during `workbloom setup`.

## Solution
- Added `was_branch_merged_to_main()` method that checks if a branch's HEAD commit is actually a parent of any merge commit in main
- This correctly distinguishes between:
  - New branches that haven't diverged from main yet
  - Branches whose commits were actually merged into main
- Added 24-hour safety check for recently created worktrees as additional protection

## Test plan
- [x] Create a new branch with `git branch test-branch`
- [x] Verify it appears in `git branch --merged main`
- [x] Run `workbloom cleanup --merged` and verify the branch is skipped with message: "not actually merged - possibly newly created"
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)