### PR TITLE
fix: Fix auto-release workflow awk syntax error

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -42,28 +42,36 @@ jobs:
         id: changelog
         run: |
           VERSION="${{ steps.cargo_version.outputs.VERSION }}"
+          # Escape dots in version for regex
+          VERSION_REGEX=$(echo "$VERSION" | sed 's/\./\\./g')
+          
           # Extract the section for this version from CHANGELOG.md
-          CHANGELOG=$(awk "/^## \[$VERSION\]/{flag=1; next} /^## \[/{flag=0} flag" CHANGELOG.md | sed '/^$/d')
+          CHANGELOG=$(awk "/^## \[$VERSION_REGEX\]/{flag=1; next} /^## \[/{flag=0} flag" CHANGELOG.md | sed '/^$/d')
           
-          # Escape for GitHub Actions
-          CHANGELOG="${CHANGELOG//'%'/'%25'}"
-          CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
-          CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
+          # If changelog is empty, use a default message
+          if [ -z "$CHANGELOG" ]; then
+            CHANGELOG="Release v$VERSION"
+          fi
           
-          echo "CONTENT=$CHANGELOG" >> $GITHUB_OUTPUT
+          # Save to file to handle multiline content properly
+          echo "$CHANGELOG" > changelog_content.txt
+          
+          # Set output using delimiter
+          echo "CONTENT<<EOF" >> $GITHUB_OUTPUT
+          cat changelog_content.txt >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
       
       - name: Create and push tag
         if: steps.tag_exists.outputs.EXISTS == 'false'
         run: |
           VERSION="${{ steps.cargo_version.outputs.VERSION }}"
-          CHANGELOG="${{ steps.changelog.outputs.CONTENT }}"
           
           # Configure git
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           
-          # Create annotated tag with changelog
-          git tag -a "v$VERSION" -m "Release v$VERSION" -m "$CHANGELOG"
+          # Create annotated tag with changelog content from file
+          git tag -a "v$VERSION" -m "Release v$VERSION" -m "$(cat changelog_content.txt)"
           
           # Push the tag
           git push origin "v$VERSION"


### PR DESCRIPTION
## Summary
- Fixes the awk syntax error in auto-release workflow that was causing the action to fail
- Properly handles multiline changelog content

## Problem
The auto-release workflow failed with an awk syntax error when trying to extract version-specific content from CHANGELOG.md:
https://github.com/chaspy/workbloom/actions/runs/16385895879/job/46305345251

## Solution
1. **Escape dots in version regex**: Version numbers like `0.1.4` contain dots that need to be escaped in awk regex
2. **Use temporary file for multiline content**: Handle multiline changelog content properly using a temporary file and EOF delimiter
3. **Add fallback**: If changelog extraction fails, use a default message

## Test plan
- [x] The workflow syntax is valid
- [x] Version regex properly escapes dots (e.g., `0.1.4` → `0\.1\.4`)
- [ ] Will be tested on next merge to main

🤖 Generated with [Claude Code](https://claude.ai/code)