### PR TITLE
fix: Handle existing releases in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
   create-release:
     name: Create Release
     runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.get_release.outputs.upload_url || steps.create_release.outputs.upload_url }}
     steps:
       - uses: actions/checkout@v4
       
@@ -22,7 +24,17 @@ jobs:
         id: get_version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
       
+      - name: Check if release exists
+        id: get_release
+        uses: cardinalby/git-get-release-action@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          tag: ${{ github.ref_name }}
+        continue-on-error: true
+      
       - name: Create Release
+        if: steps.get_release.outcome == 'failure'
         id: create_release
         uses: softprops/action-gh-release@v1
         with:
@@ -35,8 +47,6 @@ jobs:
           draft: false
           prerelease: false
           generate_release_notes: true
-          # Allow updating existing releases
-          allowUpdates: true
 
   build-and-upload:
     name: Build and Upload


### PR DESCRIPTION
## Summary
Fixes the release workflow to handle cases where a GitHub release already exists.

## Problem
The current release workflow fails when trying to create a release that already exists, which prevents the subsequent build and publish jobs from running:
- Error: `[{"resource":"Release","code":"already_exists","field":"tag_name"}]`
- This happened with v0.1.4: https://github.com/chaspy/workbloom/actions/runs/16385895879

## Solution
1. **Check if release exists first**: Use `cardinalby/git-get-release-action` to check if a release already exists
2. **Skip creation if exists**: Only create a new release if one doesn't exist
3. **Pass upload URL correctly**: Output the upload URL from either the existing or newly created release

This allows the workflow to:
- Be re-run if it fails partway through
- Handle cases where a release was manually created
- Still build and upload binaries even if the release creation step was already done

## Test plan
- [x] Workflow syntax is valid
- [ ] Will be tested on next tag push or manual workflow run

🤖 Generated with [Claude Code](https://claude.ai/code)