### PR TITLE
chore: Release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5] - 2025-01-19
+
+### Added
+- Auto-release workflow that automatically creates tags when version is updated in Cargo.toml
+
+### Fixed
+- Fix auto-release workflow awk syntax error for proper CHANGELOG extraction
+- Handle existing releases in release workflow to prevent "release already exists" errors
+- Prevent build-and-upload jobs from trying to create duplicate releases
+
+### Changed
+- Improved CI/CD workflows for more reliable releases
+
 ## [0.1.4] - 2025-01-19
 
 ### Fixed
@@ -47,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial features
 
+[0.1.5]: https://github.com/chaspy/workbloom/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/chaspy/workbloom/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/chaspy/workbloom/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/chaspy/workbloom/compare/v0.1.1...v0.1.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "workbloom"
-version = "0.1.3"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workbloom"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 authors = ["chaspy <chaspy+git@gmail.com>"]
 description = "A Git worktree management tool with automatic file copying and port allocation"


### PR DESCRIPTION
## Summary
Release v0.1.5 with improvements to CI/CD workflows for more reliable release automation.

## Changes
- Auto-release workflow that automatically creates tags when version is updated in Cargo.toml
- Fixed auto-release workflow awk syntax error for proper CHANGELOG extraction
- Handle existing releases in release workflow to prevent "release already exists" errors
- Prevent build-and-upload jobs from trying to create duplicate releases

## Release Process
1. Merge this PR
2. The auto-release workflow will automatically:
   - Create a `v0.1.5` tag
   - Create a GitHub Release
   - Build and upload binaries
   - Publish to crates.io

🤖 Generated with [Claude Code](https://claude.ai/code)