### PR TITLE
feat: Add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g., v0.1.5)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -17,12 +23,25 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       upload_url: ${{ steps.get_release.outputs.upload_url || steps.create_release.outputs.upload_url }}
+      tag: ${{ steps.get_version.outputs.TAG }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref }}
       
       - name: Get version from tag
         id: get_version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # Manual trigger - use input tag
+            VERSION="${{ github.event.inputs.tag }}"
+            VERSION="${VERSION#v}"  # Remove 'v' prefix if present
+          else
+            # Tag push trigger
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          fi
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "TAG=v$VERSION" >> $GITHUB_OUTPUT
       
       - name: Check if release exists
         id: get_release
@@ -30,7 +49,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          tag: ${{ github.ref_name }}
+          tag: ${{ steps.get_version.outputs.TAG }}
         continue-on-error: true
       
       - name: Create Release
@@ -38,7 +57,7 @@ jobs:
         id: create_release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ github.ref }}
+          tag_name: ${{ steps.get_version.outputs.TAG }}
           name: Release v${{ steps.get_version.outputs.VERSION }}
           body: |
             ## Changes in v${{ steps.get_version.outputs.VERSION }}
@@ -69,6 +88,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref }}
       
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -87,7 +108,7 @@ jobs:
       - name: Upload Release Asset
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ github.ref }}
+          tag_name: ${{ needs.create-release.outputs.tag }}
           files: ./${{ matrix.asset_name }}.tar.gz
           fail_on_unmatched_files: false
 
@@ -97,6 +118,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref }}
       
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
Adds manual trigger capability to the release workflow, allowing releases to be run manually from GitHub Actions UI.

## Why this is needed
Currently, the release workflow only triggers on tag push. However:
- Tags created by GITHUB_TOKEN don't trigger other workflows (GitHub security feature)
- If a release fails partway through, there's no way to re-run it
- For v0.1.5, the tag was created but the release workflow didn't run

## Changes
1. **Added workflow_dispatch trigger** with tag input parameter
2. **Updated all tag references** to work with both automatic and manual triggers:
   - Checkout steps use the correct ref
   - Version extraction handles both scenarios
   - Tag references use a unified approach

## How to use
1. Go to Actions → Release workflow
2. Click "Run workflow"
3. Enter a tag (e.g., `v0.1.5`)
4. Click "Run workflow"

## Testing
- [x] Workflow syntax is valid
- [x] All tag references are updated consistently
- [ ] Can be tested by running manually for v0.1.5 after merge

This will allow us to complete the v0.1.5 release by manually triggering the workflow.

🤖 Generated with [Claude Code](https://claude.ai/code)