### PR TITLE
feat: add direct cargo publish to auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -78,7 +78,7 @@ jobs:
           
           echo "Created and pushed tag v$VERSION"
       
-      - name: Trigger release workflow
+      - name: Create GitHub Release
         if: steps.tag_exists.outputs.EXISTS == 'false'
         run: |
           VERSION="${{ steps.cargo_version.outputs.VERSION }}"
@@ -126,3 +126,12 @@ jobs:
             cat /tmp/release_response.json
             exit 1
           fi
+      
+      - name: Install Rust
+        if: steps.tag_exists.outputs.EXISTS == 'false'
+        uses: dtolnay/rust-toolchain@stable
+      
+      - name: Publish to crates.io
+        if: steps.tag_exists.outputs.EXISTS == 'false'
+        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        continue-on-error: true  # Continue even if already published


### PR DESCRIPTION
## Summary
- Add cargo publish directly to auto-release workflow
- This eliminates the dependency on separate release workflow triggering
- Solves the issue where GitHub Actions doesn't trigger workflows from GITHUB_TOKEN pushes

## Background
Currently, when auto-release.yml creates a tag using GITHUB_TOKEN, it doesn't trigger the release.yml workflow due to GitHub Actions security restrictions. This caused v0.1.7 to not be published to crates.io automatically.

## Changes
- Added Rust installation step
- Added cargo publish step with CARGO_REGISTRY_TOKEN
- Renamed "Trigger release workflow" to "Create GitHub Release" for clarity

## Test plan
- [ ] Push a version bump to Cargo.toml
- [ ] Verify auto-release workflow creates tag, GitHub release, and publishes to crates.io
- [ ] Ensure CARGO_REGISTRY_TOKEN secret is properly configured

🤖 Generated with [Claude Code](https://claude.ai/code)