### PR TITLE
Fix: Add --allow-dirty flag to cargo publish

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -174,7 +174,7 @@ jobs:
         if: steps.tag_exists.outputs.EXISTS == 'false'
         run: |
           echo "Publishing to crates.io..."
-          PUBLISH_OUTPUT=$(cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} 2>&1 || true)
+          PUBLISH_OUTPUT=$(cargo publish --allow-dirty --token ${{ secrets.CARGO_REGISTRY_TOKEN }} 2>&1 || true)
           echo "$PUBLISH_OUTPUT"
           
           if echo "$PUBLISH_OUTPUT" | grep -q "already uploaded"; then


### PR DESCRIPTION
## Summary
- Fix cargo publish failure in auto-release workflow by adding `--allow-dirty` flag

## Problem
The auto-release workflow was failing to publish to crates.io because:
- The workflow creates temporary files during execution (changelog_content.txt)
- cargo publish requires a clean git state by default
- This caused v0.1.8 to fail publishing to crates.io

## Solution
Add `--allow-dirty` flag to the cargo publish command to allow publishing with uncommitted changes that are created during the workflow execution.

## Test plan
- [x] Modified the workflow file
- [ ] After merging, manually trigger the workflow with v0.1.8 tag to publish to crates.io

🤖 Generated with [Claude Code](https://claude.ai/code)