### PR TITLE
Fix: Auto-publish v0.1.8 to crates.io without manual intervention

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'Cargo.toml'
+      - '.github/workflows/auto-release.yml'
   workflow_dispatch:
     inputs:
       tag:
@@ -149,7 +150,8 @@ jobs:
           fi
       
       - name: Install Rust
-        if: steps.tag_exists.outputs.EXISTS == 'false' || github.event_name == 'workflow_dispatch'
+        # Need Rust for cargo publish regardless of tag existence
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: dtolnay/rust-toolchain@stable
       
       - name: Check code quality
@@ -162,7 +164,8 @@ jobs:
           echo "Code quality checks passed ✅"
       
       - name: Verify registry token
-        if: steps.tag_exists.outputs.EXISTS == 'false' || github.event_name == 'workflow_dispatch'
+        # Need to verify token for cargo publish
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         run: |
           if [ -z "${{ secrets.CARGO_REGISTRY_TOKEN }}" ]; then
             echo "❌ CARGO_REGISTRY_TOKEN secret is not set"
@@ -171,7 +174,8 @@ jobs:
           echo "✅ CARGO_REGISTRY_TOKEN is configured"
       
       - name: Publish to crates.io
-        if: steps.tag_exists.outputs.EXISTS == 'false' || github.event_name == 'workflow_dispatch'
+        # Always try to publish - cargo will handle if already published
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         run: |
           echo "Publishing to crates.io..."
           PUBLISH_OUTPUT=$(cargo publish --allow-dirty --token ${{ secrets.CARGO_REGISTRY_TOKEN }} 2>&1 || true)


### PR DESCRIPTION
## Summary
- Auto-publish v0.1.8 to crates.io when this PR is merged
- No manual commands needed\!

## Problem
v0.1.8 was not published to crates.io because:
1. The initial auto-release failed due to uncommitted files (fixed in #35)
2. Manual re-runs skip publishing steps for existing tags
3. Human intervention was required to run commands

## Solution
1. **Trigger on workflow file changes**: Added `.github/workflows/auto-release.yml` to paths trigger
2. **Always attempt publish on push**: Changed publish condition to run on all push events
3. **Handle already published gracefully**: cargo publish returns "already uploaded" which we treat as success

Key changes:
- Install Rust: Run on push events (needed for cargo publish)
- Verify registry token: Run on push events  
- **Publish to crates.io**: Always run on push events

## How it works
When this PR merges:
1. Workflow triggers automatically (because auto-release.yml changed)
2. Detects v0.1.8 tag already exists
3. Skips tag/release creation
4. **Runs cargo publish for v0.1.8**
5. Success\! No human intervention needed

🤖 Generated with [Claude Code](https://claude.ai/code)