### PR TITLE
feat: add short command aliases for improved usability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2025-08-15
+
+### Added
+- Short command aliases for improved usability: `s` for `setup` and `c` for `cleanup`
+- Documentation for shell alias `wb` to further reduce typing
+
+### Changed
+- Enhanced README with shell integration recommendations for shorter commands
+
 ## [0.3.0] - 2025-08-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "workbloom"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workbloom"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["chaspy <chaspy+git@gmail.com>"]
 description = "A Git worktree management tool with automatic file copying"

--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ cargo install --path .
 
 ### Shell Integration (Recommended)
 
+#### Alias for shorter commands
+
+Add this alias to your `.bashrc` or `.zshrc` for shorter commands:
+
+```bash
+alias wb='workbloom'
+```
+
+With this alias and the built-in short aliases, you can use:
+- `wb s feature/my-feature` instead of `workbloom setup feature/my-feature`
+- `wb c` instead of `workbloom cleanup`
+
+#### Auto-change directory after setup
+
 To automatically change to the worktree directory after setup, add this function to your `.bashrc` or `.zshrc`:
 
 ```bash
@@ -51,7 +65,21 @@ workbloom-setup() {
     fi
 }
 
+# Or with the alias:
+wb-setup() {
+    local output=$(wb s "$@")
+    echo "$output"
+    
+    # Extract the worktree path and change to it
+    local worktree_path=$(echo "$output" | grep "📍 Worktree location:" | sed 's/.*: //')
+    if [ -n "$worktree_path" ] && [ -d "$worktree_path" ]; then
+        cd "$worktree_path"
+        echo "📂 Changed to worktree directory: $(pwd)"
+    fi
+}
+
 # Then use: workbloom-setup feature/my-feature
+# Or: wb-setup feature/my-feature
 ```
 
 ## Usage
@@ -61,9 +89,11 @@ workbloom-setup() {
 ```bash
 # Setup and start a new shell in the worktree directory (default)
 workbloom setup feature/my-new-feature
+# Or using short alias: wb s feature/my-new-feature
 
 # Setup without starting a shell
 workbloom setup feature/my-new-feature --no-shell
+# Or using short alias: wb s feature/my-new-feature --no-shell
 ```
 
 This will:
@@ -77,15 +107,19 @@ This will:
 ```bash
 # Remove merged worktrees (default)
 workbloom cleanup
+# Or using short alias: wb c
 
 # Remove worktrees matching a pattern
 workbloom cleanup --pattern "feature/old-"
+# Or using short alias: wb c --pattern "feature/old-"
 
 # Interactive cleanup
 workbloom cleanup --interactive
+# Or using short alias: wb c --interactive
 
 # Show merge status of all worktrees
 workbloom cleanup --status
+# Or using short alias: wb c --status
 ```
 
 ## Configuration

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    #[command(about = "Set up a new git worktree with automatic file copying")]
+    #[command(about = "Set up a new git worktree with automatic file copying", visible_alias = "s")]
     Setup {
         #[arg(help = "The branch name for the worktree")]
         branch_name: String,
@@ -27,7 +27,7 @@ enum Commands {
         no_shell: bool,
     },
     
-    #[command(about = "Clean up worktrees")]
+    #[command(about = "Clean up worktrees", visible_alias = "c")]
     Cleanup {
         #[arg(long, conflicts_with_all = &["pattern", "interactive", "status"], help = "Remove only merged worktrees")]
         merged: bool,


### PR DESCRIPTION
## Summary
- Add short command aliases (`s` for `setup`, `c` for `cleanup`) to reduce typing
- Update documentation with shell alias recommendations
- Bump version to 0.4.0

## Motivation
The user frequently uses `workbloom setup` command and found it too long to type. This PR introduces short aliases to improve developer experience.

## Changes
- ✨ Add `visible_alias` attributes to clap subcommands in `src/main.rs`
- 📝 Update README with shell alias (`wb`) and command alias usage examples
- 📝 Update CHANGELOG for version 0.4.0
- ⬆️ Bump version in Cargo.toml to 0.4.0

## Usage Example
```bash
# With shell alias 'wb' and short commands:
# Before: workbloom setup feature/my-new-feature (40 characters)
# After:  wb s feature/my-new-feature (27 characters)
# Reduction: 32.5%
```

## Test plan
- [x] Build the project successfully
- [x] Verify `workbloom s --help` shows setup help
- [x] Verify `workbloom c --help` shows cleanup help
- [x] Verify aliases appear in main help output

🤖 Generated with [Claude Code](https://claude.ai/code)