### PR TITLE
feat: add --force option to cleanup command for better worktree management

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workbloom"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 authors = ["chaspy <chaspy+git@gmail.com>"]
 description = "A Git worktree management tool with automatic file copying"

--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ This will:
 workbloom cleanup
 # Or using short alias: wb c
 
+# Force removal of merged worktrees (skip remote branch checks)
+workbloom cleanup --merged --force
+# Or using short alias: wb c --merged --force
+
 # Remove worktrees matching a pattern
 workbloom cleanup --pattern "feature/old-"
 # Or using short alias: wb c --pattern "feature/old-"
@@ -121,6 +125,16 @@ workbloom cleanup --interactive
 workbloom cleanup --status
 # Or using short alias: wb c --status
 ```
+
+#### Cleanup Options
+
+- **Default**: Removes only merged worktrees that exist on the remote repository
+- **`--force`**: Skips remote branch checks and removes all merged worktrees (use with caution)
+  - Useful when remote branches have been deleted after merging
+  - Still protects recently created worktrees (within 24 hours)
+- **`--pattern`**: Removes worktrees matching the specified pattern
+- **`--interactive`**: Prompts for confirmation before removing each worktree
+- **`--status`**: Shows the merge status of all branches without removing anything
 
 ## Configuration
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,9 @@ enum Commands {
         
         #[arg(long, conflicts_with_all = &["merged", "pattern", "interactive"], help = "Show merge status of all branches")]
         status: bool,
+
+        #[arg(long, help = "Force cleanup without remote branch checks (use with --merged)")]
+        force: bool,
     },
 }
 
@@ -57,9 +60,10 @@ fn main() -> Result<()> {
             pattern,
             interactive,
             status,
+            force,
         } => {
             let mode = if merged || (pattern.is_none() && !interactive && !status) {
-                cleanup::CleanupMode::Merged
+                cleanup::CleanupMode::Merged { force }
             } else if let Some(p) = pattern {
                 cleanup::CleanupMode::Pattern(p)
             } else if interactive {

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ enum Commands {
         #[arg(long, conflicts_with_all = &["merged", "pattern", "interactive"], help = "Show merge status of all branches")]
         status: bool,
 
-        #[arg(long, help = "Force cleanup without remote branch checks (use with --merged)")]
+        #[arg(long, help = "Force cleanup without remote branch checks (use with --merged). Still protects recently created worktrees")]
         force: bool,
     },
 }


### PR DESCRIPTION
## Summary

- Add `--force` flag to skip remote branch checks when cleaning up merged worktrees
- Resolves issue where merged branches were skipped due to deleted remote branches after merging
- Maintains safety check for recently created worktrees (within 24 hours)
- Update README with comprehensive cleanup options documentation

## Problem

The cleanup command was skipping many merged worktrees because it only removed branches that existed on remote. After PRs are merged and remote branches are deleted, these worktrees couldn't be cleaned up automatically.

## Solution

Added `--force` option that:
- Skips remote branch existence checks
- Still protects recently created worktrees (within 24 hours)
- Allows cleanup of merged worktrees even when remote branches are deleted
- Maintains all other safety checks

## Usage

```bash
# Force cleanup all merged worktrees (skip remote checks)
workbloom cleanup --merged --force
```

## Test plan

- [x] Test cleanup without --force (existing behavior preserved)
- [x] Test cleanup with --force (removes previously skipped merged worktrees)
- [x] Verify recently created worktrees are still protected
- [x] Update README documentation

🤖 Generated with [Claude Code](https://claude.ai/code)