### PR TITLE
fix: avoid hanging when creating zellij session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "workbloom"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workbloom"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 authors = ["chaspy <chaspy+git@gmail.com>"]
 description = "A Git worktree management tool with automatic file copying"

--- a/src/multiplexer.rs
+++ b/src/multiplexer.rs
@@ -91,19 +91,27 @@ impl MultiplexerClient for RealMultiplexerClient {
     fn create_session(&self, backend: Backend, session_name: &str, directory: &Path) -> Result<()> {
         match backend {
             Backend::Zellij => {
-                let status = Command::new("zellij")
+                Command::new("zellij")
                     .args(["attach", "--create-background", session_name])
                     .current_dir(directory)
+                    .stdin(Stdio::null())
                     .stdout(Stdio::null())
                     .stderr(Stdio::null())
-                    .status()
+                    .spawn()
                     .with_context(|| format!("Failed to create zellij session '{session_name}'"))?;
 
-                if status.success() {
-                    Ok(())
-                } else {
-                    bail!("zellij failed to create session")
+                // Poll until the session appears (up to 3 seconds)
+                for _ in 0..15 {
+                    std::thread::sleep(std::time::Duration::from_millis(200));
+                    if zellij_sessions()
+                        .unwrap_or_default()
+                        .iter()
+                        .any(|n| n == session_name)
+                    {
+                        return Ok(());
+                    }
                 }
+                bail!("zellij session '{session_name}' was not created within timeout")
             }
             Backend::Tmux => {
                 let status = Command::new("tmux")


### PR DESCRIPTION
## Summary

- `zellij attach --create-background` が `.status()` でブロックし、100% ハングする問題を修正
- zellij サーバーはデーモンとして永遠に動き続けるため、`.status()`（子プロセス終了待ち）が返らない
- `.spawn()`（ノンブロッキング）に変更し、`zellij list-sessions` でセッション作成を確認するポーリングを追加（最大3秒）

## Root cause

`zellij attach --create-background <name>` starts a zellij server process that runs indefinitely as a background daemon. Calling `.status()` waits for the child process to exit — but the server never exits, so it hangs 100% of the time.

## Fix

Switch from `.status()` (blocking) to `.spawn()` (non-blocking), then poll `zellij list-sessions` until the named session appears, with a 3-second timeout.

## Test plan

- [ ] `wb s <branch>` で zellij セッションが固まらずに作成・アタッチされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)